### PR TITLE
Patch/speed up pypy tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
   - python setup.py develop
 # command to run tests
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy*]]; then py.test --cov-config .coveragerc --cov-report term-missing --cov fireblog; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == pypy*]]; then py.test; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then py.test --cov-config .coveragerc --cov-report term-missing --cov fireblog; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then py.test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ python:
 install:
   - python setup.py develop
 # command to run tests
-script: py.test
+script:
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy*]]; then py.test --cov-config .coveragerc --cov-report term-missing --cov fireblog; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == pypy*]]; then py.test; fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov-config .coveragerc --cov-report term-missing --cov fireblog --pep8 fireblog/tests
+addopts = --pep8 fireblog/tests
 python_files =  *.py
 norecursedirs = alembic
 pep8ignore =


### PR DESCRIPTION
Avoid running coverage.py when running tests on pypy, as atm coverage.py runs slow on pypy, see https://bitbucket.org/pypy/pypy/issues/1871/10x-slower-than-cpython-under-coverage.
