### PR TITLE
Patch/convert max rss items to int

### DIFF
--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -40,6 +40,8 @@ def persona_test_admin_login():
 @pytest.fixture
 def pyramid_req(theme):
     res = testing.DummyRequest()
+    # max_rss_items is set as a str to test that the rss view converts
+    # it to an int
     res.registry.settings.update({'fireblog.max_rss_items': '100',
                                   'fireblog.all_view_post_len': 1000,
                                   'dogpile_cache.backend': 'memory',
@@ -125,6 +127,8 @@ def setup_testapp(mydb, theme, request):
                 'persona.secret': 'some_secret',
                 'dogpile_cache.backend': 'memory',
                 'fireblog.all_view_post_len': 1000,
+                # max_rss_items is set as a str to test that
+                # the rss view converts it to an int
                 'fireblog.max_rss_items': '100',
                 'fireblog.theme': theme,
                 'fireblog.recaptcha-secret': 'secret...'}

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -40,7 +40,7 @@ def persona_test_admin_login():
 @pytest.fixture
 def pyramid_req(theme):
     res = testing.DummyRequest()
-    res.registry.settings.update({'fireblog.max_rss_items': 100,
+    res.registry.settings.update({'fireblog.max_rss_items': '100',
                                   'fireblog.all_view_post_len': 1000,
                                   'dogpile_cache.backend': 'memory',
                                   'fireblog.theme': theme,
@@ -125,7 +125,7 @@ def setup_testapp(mydb, theme, request):
                 'persona.secret': 'some_secret',
                 'dogpile_cache.backend': 'memory',
                 'fireblog.all_view_post_len': 1000,
-                'fireblog.max_rss_items': 100,
+                'fireblog.max_rss_items': '100',
                 'fireblog.theme': theme,
                 'fireblog.recaptcha-secret': 'secret...'}
     app = fireblog.main({}, **settings)

--- a/fireblog/tests/views_test.py
+++ b/fireblog/tests/views_test.py
@@ -2,7 +2,7 @@ import pytest
 import re
 
 
-from pyramid.httpexceptions import HTTPNotFound
+from pyramid.httpexceptions import HTTPNotFound, HTTPInternalServerError
 
 import fireblog.views as views
 import fireblog.tags
@@ -393,6 +393,12 @@ class Test_rss:
         response = views.render_rss_feed(pyramid_req)
         assert self.rss_success_text_1 in response.text
         assert self.rss_success_text_2 in response.text
+
+    @pytest.mark.parametrize('invalid', ['invalid', None])
+    def test_get_http500_when_max_rss_items_setting_is_invalid(self, invalid, pyramid_config, pyramid_req):
+        pyramid_req.registry.settings['fireblog.max_rss_items'] = invalid
+        res = views.render_rss_feed(pyramid_req)
+        assert isinstance(res, HTTPInternalServerError)
 
 
 class Test_uuid:

--- a/fireblog/tests/views_test.py
+++ b/fireblog/tests/views_test.py
@@ -395,7 +395,8 @@ class Test_rss:
         assert self.rss_success_text_2 in response.text
 
     @pytest.mark.parametrize('invalid', ['invalid', None])
-    def test_get_http500_when_max_rss_items_setting_is_invalid(self, invalid, pyramid_config, pyramid_req):
+    def test_get_http500_when_max_rss_items_setting_is_invalid(
+            self, invalid, pyramid_config, pyramid_req):
         pyramid_req.registry.settings['fireblog.max_rss_items'] = invalid
         res = views.render_rss_feed(pyramid_req)
         assert isinstance(res, HTTPInternalServerError)

--- a/fireblog/views.py
+++ b/fireblog/views.py
@@ -30,7 +30,7 @@ def render_rss_feed(request):
     max_rss_items = request.registry.settings['fireblog.max_rss_items']
     try:
         max_rss_items = int(max_rss_items)
-    except TypeError:
+    except Exception:
         return HTTPInternalServerError()
     posts = DBSession.query(Post).order_by(desc(Post.created)).all()
     items = []

--- a/fireblog/views.py
+++ b/fireblog/views.py
@@ -13,6 +13,7 @@ from pyramid.response import Response
 from pyramid.httpexceptions import (
     HTTPFound,
     HTTPNotFound,
+    HTTPInternalServerError
 )
 import sqlalchemy.sql as sql
 from sqlalchemy import desc
@@ -25,8 +26,12 @@ from fireblog.models import (
 
 @view_config(route_name='rss')
 def render_rss_feed(request):
-    max_rss_items = request.registry.settings['fireblog.max_rss_items']
     "Generate an RSS feed of all posts."
+    max_rss_items = request.registry.settings['fireblog.max_rss_items']
+    try:
+        max_rss_items = int(max_rss_items)
+    except TypeError:
+        return HTTPInternalServerError()
     posts = DBSession.query(Post).order_by(desc(Post.created)).all()
     items = []
     for post in posts[:max_rss_items]:


### PR DESCRIPTION
Fix a bug where the rss view fails, as the max_rss_items setting is by default a string, not an int
