### PR TITLE
Store reponse dict on Response object

### DIFF
--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -21,7 +21,13 @@ def template_response_adapter(s: utils.TemplateResponseDict):
     returns a :py:class:`pyramid.response.Response` containing a string
     representation of s."""
     assert isinstance(s, utils.TemplateResponseDict)
-    response = Response(repr(s))
+    # We need to return a Response() object, as per the Pyramid specs. But we
+    # want to not store a string in the Response yet, but an arbitrary dict
+    # as after this function returns, :py:func:`use_template` will do further
+    # processing on this arbitrary dict. So we set a custom field on this
+    # Respnse object, which we can retrieve in :py:func:`use_template`.
+    response = Response()
+    response._fireblog_custom_response = s
     return response
 
 

--- a/fireblog/utils.py
+++ b/fireblog/utils.py
@@ -58,7 +58,9 @@ def use_template(template: str=None):
             # Deal with eg HTTPFound or HTTPNotFound by just returning them.
             if isinstance(res, HTTPException):
                 return res
-            to_render = eval(res.text)
+            # Pull out the custom dict object set by
+            # :py:func:`fireblog.template_response_adapter`
+            to_render = res._fireblog_custom_response
             if not isinstance(to_render, dict):
                 raise Exception(  # pragma: no cover
                     "The use_template decorator is being used "


### PR DESCRIPTION
This is better than using repr, as it means we store a ref to the actual dict, rather than a representation of the dict. This means that functions and stuff can be in the dict.
