### PR TITLE
Feature/reduce num of tests

### DIFF
--- a/fireblog/tests/__init___test.py
+++ b/fireblog/tests/__init___test.py
@@ -1,6 +1,8 @@
 import pytest
 import fireblog
 
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
 
 class Test_groupfinder:
 

--- a/fireblog/tests/comments_test.py
+++ b/fireblog/tests/comments_test.py
@@ -10,6 +10,9 @@ except ImportError:
     import mock  # python3.2 support
 
 
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
 class Test_comment_view:
 
     @staticmethod

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -28,6 +28,12 @@ def theme(request):
 
 
 @pytest.fixture(scope='session')
+def test_with_one_theme(theme):
+    if theme != 'bootstrap':
+        pytest.skip("This test doesn't need to be run against all themes.")
+
+
+@pytest.fixture(scope='session')
 def persona_test_admin_login():
     data = requests.get(
         'http://personatestuser.org/email_with_assertion/'

--- a/fireblog/tests/models_test.py
+++ b/fireblog/tests/models_test.py
@@ -6,6 +6,9 @@ except ImportError:
     import mock  # python3.2 support
 
 
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
 class Test_create_username:
 
     def test_func_called_with_bad_context(self):

--- a/fireblog/tests/settings/___init___test.py
+++ b/fireblog/tests/settings/___init___test.py
@@ -7,6 +7,10 @@ from fireblog.settings.mapping import Entry
 from hypothesis import given
 import hypothesis.strategies as st
 import transaction
+import pytest
+
+
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
 
 
 class Test_get_settings_during_startup:

--- a/fireblog/tests/settings/db_wrapper_test.py
+++ b/fireblog/tests/settings/db_wrapper_test.py
@@ -2,6 +2,9 @@ import pytest
 from fireblog.settings import settings_dict
 
 
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
 def test_can_set_an_item_and_then_get_the_same_item(pyramid_config):
     assert not settings_dict.get('test', None)
     settings_dict['test'] = 'test_str'

--- a/fireblog/tests/settings/views_test.py
+++ b/fireblog/tests/settings/views_test.py
@@ -2,6 +2,10 @@ from fireblog.settings.views import Settings
 from fireblog.settings import mapping, settings_dict
 from pyramid.httpexceptions import HTTPFound
 import transaction
+import pytest
+
+
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
 
 
 def test_GET_settings(pyramid_config, pyramid_req, theme):

--- a/fireblog/tests/tags_test.py
+++ b/fireblog/tests/tags_test.py
@@ -4,6 +4,9 @@ from fireblog.views import Post_modifying_views
 from pyramid.httpexceptions import HTTPNotFound
 
 
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
 class Test_tag_view:
 
     @pytest.mark.parametrize("tag, actual_posts", [

--- a/fireblog/tests/views_test.py
+++ b/fireblog/tests/views_test.py
@@ -33,7 +33,7 @@ class Test_add_post:
         del request.matchdict['postname']
         return res
 
-    def test_GET_success(self, pyramid_config, pyramid_req):
+    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'somenewpage'
         response = Add_Post(pyramid_req).add_post()
         assert 'somenewpage' in response['title']
@@ -41,7 +41,7 @@ class Test_add_post:
         assert response[
             'save_url'] == 'http://example.com/add_post/somenewpage'
 
-    def test_GET_failure(self, pyramid_config, pyramid_req):
+    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         response = Add_Post(pyramid_req).add_post()
         assert response.location == 'http://example.com/posts/1/Homepage/edit'
@@ -76,7 +76,7 @@ class Test_add_post:
         assert response[
             'next_page'] == 'http://example.com/posts/3/' + postname
 
-    def test_POST_failure(self, pyramid_config, pyramid_req):
+    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         response = self.submit_add_post(pyramid_req, postname='Homepage',
                                         body='Some test body.',
                                         tags='tag2')
@@ -108,6 +108,7 @@ class Test_view_post:
         assert isinstance(response, HTTPNotFound)
 
 
+@pytest.mark.usefixtures("test_with_one_theme")
 class Test_view_all_posts:
 
     def test_success(self, pyramid_config, pyramid_req):
@@ -176,6 +177,7 @@ that is all.'''
             assert posts[0][e] == v
 
 
+@pytest.mark.usefixtures("test_with_one_theme")
 class Test_view_multiple_posts_pager:
     "Test the pager functionality on both view_all_posts and tag_view views"
 
@@ -260,7 +262,7 @@ class Test_view_multiple_posts_pager:
 
 class Test_edit_post:
 
-    def test_GET_success(self, pyramid_config, pyramid_req):
+    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 1
         response = Post_modifying_views(pyramid_req).edit_post()
@@ -269,7 +271,7 @@ class Test_edit_post:
         assert response['save_url'] == ('http://example.com/'
                                         'posts/1/Homepage/edit')
 
-    def test_GET_failure(self, pyramid_config, pyramid_req):
+    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         # Only the id should be being checked, not the postname
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
@@ -296,7 +298,7 @@ class Test_edit_post:
         assert 'test1' in response['tags']
         assert 'test2' in response['tags']
 
-    def test_POST_failure(self, pyramid_config, pyramid_req):
+    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         # Only the id should be being checked, not the postname
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
@@ -306,7 +308,7 @@ class Test_edit_post:
 
 class Test_del_post:
 
-    def test_GET_success(self, pyramid_config, pyramid_req):
+    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 1
         response = Post_modifying_views(pyramid_req).del_post()
@@ -314,7 +316,7 @@ class Test_del_post:
         assert response['save_url'] == ('http://example.com/'
                                         'posts/1/Homepage/del')
 
-    def test_GET_failure(self, pyramid_config, pyramid_req):
+    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         # Here, we use the same postname as an existing post, but use a
         # different id.
         pyramid_req.matchdict['postname'] = 'Homepage'
@@ -358,13 +360,14 @@ class Test_del_post:
         assert response[
             'next_page'] == 'http://example.com/posts/3/somenewpost'
 
-    def test_POST_failure(self, pyramid_config, pyramid_req):
+    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
         response = Post_modifying_views(pyramid_req).del_post_POST()
         assert response.location == 'http://example.com/'
 
 
+@pytest.mark.usefixtures("test_with_one_theme")
 class Test_rss:
     # Basically, the lastBuildDate depends on when the render_rss_feed
     # function is called. So, I've separated the output into 2 strings,
@@ -392,6 +395,7 @@ class Test_rss:
         assert self.rss_success_text_2 in response.text
 
 
+@pytest.mark.usefixtures("test_with_one_theme")
 class Test_uuid:
 
     @pytest.mark.parametrize('uuid, location', [

--- a/fireblog/tests/views_test.py
+++ b/fireblog/tests/views_test.py
@@ -33,7 +33,8 @@ class Test_add_post:
         del request.matchdict['postname']
         return res
 
-    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_success(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'somenewpage'
         response = Add_Post(pyramid_req).add_post()
         assert 'somenewpage' in response['title']
@@ -41,7 +42,8 @@ class Test_add_post:
         assert response[
             'save_url'] == 'http://example.com/add_post/somenewpage'
 
-    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_failure(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         response = Add_Post(pyramid_req).add_post()
         assert response.location == 'http://example.com/posts/1/Homepage/edit'
@@ -76,7 +78,8 @@ class Test_add_post:
         assert response[
             'next_page'] == 'http://example.com/posts/3/' + postname
 
-    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_POST_failure(self, pyramid_config,
+                          pyramid_req, test_with_one_theme):
         response = self.submit_add_post(pyramid_req, postname='Homepage',
                                         body='Some test body.',
                                         tags='tag2')
@@ -262,7 +265,8 @@ class Test_view_multiple_posts_pager:
 
 class Test_edit_post:
 
-    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_success(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 1
         response = Post_modifying_views(pyramid_req).edit_post()
@@ -271,7 +275,8 @@ class Test_edit_post:
         assert response['save_url'] == ('http://example.com/'
                                         'posts/1/Homepage/edit')
 
-    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_failure(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         # Only the id should be being checked, not the postname
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
@@ -298,7 +303,8 @@ class Test_edit_post:
         assert 'test1' in response['tags']
         assert 'test2' in response['tags']
 
-    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_POST_failure(self, pyramid_config,
+                          pyramid_req, test_with_one_theme):
         # Only the id should be being checked, not the postname
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
@@ -308,7 +314,8 @@ class Test_edit_post:
 
 class Test_del_post:
 
-    def test_GET_success(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_success(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 1
         response = Post_modifying_views(pyramid_req).del_post()
@@ -316,7 +323,8 @@ class Test_del_post:
         assert response['save_url'] == ('http://example.com/'
                                         'posts/1/Homepage/del')
 
-    def test_GET_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_GET_failure(self, pyramid_config, pyramid_req,
+                         test_with_one_theme):
         # Here, we use the same postname as an existing post, but use a
         # different id.
         pyramid_req.matchdict['postname'] = 'Homepage'
@@ -360,7 +368,8 @@ class Test_del_post:
         assert response[
             'next_page'] == 'http://example.com/posts/3/somenewpost'
 
-    def test_POST_failure(self, pyramid_config, pyramid_req, test_with_one_theme):
+    def test_POST_failure(self, pyramid_config,
+                          pyramid_req, test_with_one_theme):
         pyramid_req.matchdict['postname'] = 'Homepage'
         pyramid_req.matchdict['id'] = 3
         response = Post_modifying_views(pyramid_req).del_post_POST()


### PR DESCRIPTION
Skip tests that only need to be tested with one theme. By default, a lot of tests were being tested against all available themes, but only certain tests (such as the functional tests) really required this to be done. Other tests didn't involve any template rendering so could be safely skipped over.
