### PR TITLE
Feature/make blog title customisable

### DIFF
--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -61,6 +61,10 @@ def add_urlify_function(event):
     event['urlify'] = utils.urlify
 
 
+def add_settings_dict_to_templates(event):
+    event['settings_dict'] = settings_dict
+
+
 def groupfinder(userid, request) -> list:
     """Looks up and returns the groups the userid belongs to.
     If the userid doesn't exist, they are created as a commenter, and the
@@ -115,6 +119,7 @@ def add_routes(config):
 
     config.add_subscriber(add_username_function, BeforeRender)
     config.add_subscriber(add_urlify_function, BeforeRender)
+    config.add_subscriber(add_settings_dict_to_templates, BeforeRender)
 
 
 def include_all_components(config):

--- a/fireblog/templates/bootstrap/base.mako
+++ b/fireblog/templates/bootstrap/base.mako
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
 
-    <title>Not the answer--a blog</title>
+    <title>${settings_dict['persona.siteName']}</title>
   <%block name = "head">
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
@@ -41,7 +41,7 @@
 
 </div>
 <div class="page-header">
-  <h1>Not the Answer <small>A personal blog</small> ${request.persona_button}</h1>
+  <h1>${settings_dict['persona.siteName']} ${request.persona_button}</h1>
 </div>
     <div class="container">
         <h1><%block name = "header"/></h1>

--- a/fireblog/templates/polymer/base.mako
+++ b/fireblog/templates/polymer/base.mako
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
 
-    <title>Not the answer--a blog</title>
+    <title>${settings_dict['persona.siteName']}</title>
 
     <%block name="head">
     <script src="${request.get_bower_url('webcomponentsjs/webcomponents-lite.min.js')}">
@@ -56,7 +56,7 @@
     <paper-scroll-header-panel>
         <paper-toolbar class="header">
             <%block name = "header_toolbar">
-            <div class="title-text flex-1"><h1>Not the Answer - <small>A personal blog</small></h1></div>
+            <div class="title-text flex-1"><h1>${settings_dict['persona.siteName']}</h1></div>
             <div><h1>${request.persona_button}</h1></div>
             </%block>
         </paper-toolbar>


### PR DESCRIPTION
Use the persona.siteName setting wherever the sitename is displayed, so the user can change the sitename in one place and it changes everywhere.

Before this PR, the sitename was hardcoded into the templates...
