### PR TITLE
Feature/add recaptcha client key setting

### DIFF
--- a/fireblog/comments.py
+++ b/fireblog/comments.py
@@ -68,7 +68,7 @@ def comment_add(request):
     comment_text = request.params.get('comment', None)
     if not request.authenticated_userid:
         recaptcha = request.params.get('g-recaptcha-response', '')
-        recaptcha_site_secret = settings_dict['fireblog.recaptcha-secret']
+        recaptcha_site_secret = settings_dict['fireblog.recaptcha_secret']
         payload = dict(secret=recaptcha_site_secret,
                        response=recaptcha)
         result = requests.post(

--- a/fireblog/settings/mapping.py
+++ b/fireblog/settings/mapping.py
@@ -57,7 +57,7 @@ mapping = (
         'not on this list, then logins won\'t work from that domain.',
         str),
     Entry(
-        'fireblog.recaptcha-secret',
+        'fireblog.recaptcha_secret',
         'Recaptcha secret',
         'The Recaptcha secret used for server-side validation to combat spam. '
         'See https://www.google.com/recaptcha for more details.',

--- a/fireblog/settings/mapping.py
+++ b/fireblog/settings/mapping.py
@@ -62,7 +62,14 @@ mapping = (
         'The Recaptcha secret used for server-side validation to combat spam. '
         'See https://www.google.com/recaptcha for more details.',
         str,
-        validators.recaptcha_secret_validator),
+        validators.recaptcha_validator),
+    Entry(
+        'fireblog.recaptcha_site_key'
+        'Recaptcha site key'
+        'The Recaptcha site key that is included in the html Recaptcha widget.'
+        ' See https://www.google.com/recaptcha for more details.',
+        str,
+        validators.recaptcha_validator),
     Entry(
         'fireblog.theme',
         'Blog theme',

--- a/fireblog/settings/mapping.py
+++ b/fireblog/settings/mapping.py
@@ -64,8 +64,8 @@ mapping = (
         str,
         validators.recaptcha_validator),
     Entry(
-        'fireblog.recaptcha_site_key'
-        'Recaptcha site key'
+        'fireblog.recaptcha_site_key',
+        'Recaptcha site key',
         'The Recaptcha site key that is included in the html Recaptcha widget.'
         ' See https://www.google.com/recaptcha for more details.',
         str,

--- a/fireblog/settings/validators.py
+++ b/fireblog/settings/validators.py
@@ -5,7 +5,8 @@ def sitename_validator(item: str):
     return 1 <= len(item) <= 100
 
 
-def recaptcha_secret_validator(item: str):
+def recaptcha_validator(item: str):
+    'Validates both Recaptcha site key and Recaptcha secret.'
     # This is subject to Google changing the len of the recaptcha secret.
     return len(item) == 40
 

--- a/fireblog/templates/bootstrap/comments.mako
+++ b/fireblog/templates/bootstrap/comments.mako
@@ -54,7 +54,7 @@ If you want to keep track of your comments, and have\
         </div>
         <input type="hidden" name="post-id" value="${post_id}">
         <div class="form-group">
-            <div class="g-recaptcha" data-sitekey="6LdPugUTAAAAAFJMGiJpfvFjXwPTqVk0mIV9EnrD"></div>
+            <div class="g-recaptcha" data-sitekey="${settings_dict['fireblog.recaptcha_site_key']}"></div>
         </div>
         <div class="form-group">
             <input type = "submit" name = "form.submitted"

--- a/fireblog/templates/polymer/comments.mako
+++ b/fireblog/templates/polymer/comments.mako
@@ -38,7 +38,7 @@ If you want to keep track of your comments, and have\
             </label>
         <input type="hidden" name="post-id" value="${post_id}">
         <input type="hidden" name="form.submitted">
-            <div class="g-recaptcha" data-sitekey="6LdPugUTAAAAAFJMGiJpfvFjXwPTqVk0mIV9EnrD"></div>
+            <div class="g-recaptcha" data-sitekey="${settings_dict['fireblog.recaptcha_site_key']}"></div>
             <form-submit-button>Submit</form-submit-button>
         </form>
 % endif

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -48,7 +48,7 @@ def persona_test_admin_login():
 @pytest.fixture
 def pyramid_req():
     res = testing.DummyRequest()
-    res.registry.settings.update({'dogpile_cache.backend': 'memory',})
+    res.registry.settings.update({'dogpile_cache.backend': 'memory'})
     return res
 
 

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -48,12 +48,7 @@ def persona_test_admin_login():
 @pytest.fixture
 def pyramid_req():
     res = testing.DummyRequest()
-    # max_rss_items is set as a str to test that the rss view converts
-    # it to an int
-    res.registry.settings.update({'fireblog.max_rss_items': '100',
-                                  'fireblog.all_view_post_len': 1000,
-                                  'dogpile_cache.backend': 'memory',
-                                  'fireblog.recaptcha_secret': 'secret...'})
+    res.registry.settings.update({'dogpile_cache.backend': 'memory',})
     return res
 
 

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -63,7 +63,6 @@ def mydb(request, persona_test_admin_login, theme):
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
     with transaction.manager:
-        # TODO-add tags to this test data. Some tests may also need updating.
         tag1 = Tags(tag='tag1', uuid='uuid-tag111')
         tag2 = Tags(tag='tag2', uuid='uuid-tag222')
         tag3 = Tags(tag='tag3', uuid='uuid-tag333')

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -106,6 +106,8 @@ def mydb(request, persona_test_admin_login, theme):
             ('persona.audiences', 'http://localhost'),
             ('fireblog.recaptcha_secret',
              'secretsecretsecretsecretsecretsecretsecr'),
+            ('fireblog.recaptcha_site_key',
+             'secretsecretsecretsecretsecretsecretsecr'),
             ('fireblog.theme', theme))
         settings = [Settings(name=x, value=y) for x, y in settings_map]
         for e in settings:
@@ -145,7 +147,8 @@ def setup_testapp(mydb, request):
                 # max_rss_items is set as a str to test that
                 # the rss view converts it to an int
                 'fireblog.max_rss_items': '100',
-                'fireblog.recaptcha_secret': 'secret...'}
+                'fireblog.recaptcha_secret': 's' * 40,
+                'fireblog.recaptcha_site_key': 's' * 40}
     mydb.rollback()
     app = fireblog.main({}, **settings)
     return webtest.TestApp(app)

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -53,7 +53,7 @@ def pyramid_req():
     res.registry.settings.update({'fireblog.max_rss_items': '100',
                                   'fireblog.all_view_post_len': 1000,
                                   'dogpile_cache.backend': 'memory',
-                                  'fireblog.recaptcha-secret': 'secret...'})
+                                  'fireblog.recaptcha_secret': 'secret...'})
     return res
 
 
@@ -110,7 +110,7 @@ def mydb(request, persona_test_admin_login, theme):
             ('persona.siteName', 'sitename'),
             ('persona.secret', 'seekret'),
             ('persona.audiences', 'http://localhost'),
-            ('fireblog.recaptcha-secret',
+            ('fireblog.recaptcha_secret',
              'secretsecretsecretsecretsecretsecretsecr'),
             ('fireblog.theme', theme))
         settings = [Settings(name=x, value=y) for x, y in settings_map]
@@ -151,7 +151,7 @@ def setup_testapp(mydb, request):
                 # max_rss_items is set as a str to test that
                 # the rss view converts it to an int
                 'fireblog.max_rss_items': '100',
-                'fireblog.recaptcha-secret': 'secret...'}
+                'fireblog.recaptcha_secret': 'secret...'}
     mydb.rollback()
     app = fireblog.main({}, **settings)
     return webtest.TestApp(app)

--- a/fireblog/tests/functional_tests.py
+++ b/fireblog/tests/functional_tests.py
@@ -202,7 +202,7 @@ class Test_functional_tests:
             ('persona.siteName', 'sitename'),
             ('persona.secret', 'seekret'),
             ('persona.audiences', 'http://localhost'),
-            ('fireblog.recaptcha-secret',
+            ('fireblog.recaptcha_secret',
              'secretsecretsecretsecretsecretsecretsecr'),
             ('fireblog.theme', theme))
         with self.logged_in(testapp, persona_test_admin_login):

--- a/fireblog/tests/settings/___init___test.py
+++ b/fireblog/tests/settings/___init___test.py
@@ -32,7 +32,7 @@ class Test_get_settings_during_startup:
             'persona.siteName': 'sitename',
             'persona.secret': 'somesecret',
             'persona.audiences': 'http://localhost',
-            'fireblog.recaptcha-secret': 'x' * 40,
+            'fireblog.recaptcha_secret': 'x' * 40,
             'fireblog.theme': 'bootstrap'}
         # Check that settings_dict is all correct
         for key, value in expected_settings_dict.items():

--- a/fireblog/tests/settings/___init___test.py
+++ b/fireblog/tests/settings/___init___test.py
@@ -22,7 +22,7 @@ class Test_get_settings_during_startup:
         # Setup inputs to be fed in via input func
         inputs = [
             '0', '50', '999999', '500', '', 'sitename', 'http://localhost',
-            'x' * 39, 'x' * 40, 'wrong-theme', 'bootstrap']
+            'x' * 39, 'x' * 40, 's' * 41, 's' * 40, 'wrong-theme', 'bootstrap']
         input_gen = (i for i in inputs)
         monkeypatch.setattr('builtins.input', lambda prompt: next(input_gen))
         make_sure_all_settings_exist_and_are_valid()
@@ -42,7 +42,7 @@ class Test_get_settings_during_startup:
         assert not err
         out = [x for x in out.split('\n') if x]
         # 5 Invalid values were supplied
-        assert len(out) == 5
+        assert len(out) == 6
         # Check the same message was printed each time.
         assert all((x == out[0] for x in out))
 

--- a/fireblog/tests/settings/validators_test.py
+++ b/fireblog/tests/settings/validators_test.py
@@ -15,12 +15,12 @@ def test_sitename_validator_fail(s):
 
 @given(st.text(min_size=40, max_size=40))
 def test_recaptcha_validator_success(s):
-    assert v.recaptcha_secret_validator(s)
+    assert v.recaptcha_validator(s)
 
 
 @given(st.one_of(st.text(min_size=41), st.text(max_size=39)))
 def test_recaptcha_validator_fail(s):
-    assert not v.recaptcha_secret_validator(s)
+    assert not v.recaptcha_validator(s)
 
 
 @given(st.sampled_from(('bootstrap', 'polymer')))

--- a/fireblog/tests/settings/views_test.py
+++ b/fireblog/tests/settings/views_test.py
@@ -17,6 +17,8 @@ def test_GET_settings(pyramid_config, pyramid_req, theme):
         ('persona.audiences', 'http://localhost'),
         ('fireblog.recaptcha_secret',
          'secretsecretsecretsecretsecretsecretsecr'),
+        ('fireblog.recaptcha_site_key',
+         'secretsecretsecretsecretsecretsecretsecr'),
         ('fireblog.theme', theme)))
     expected_mapping = []
     for entry in mapping:
@@ -37,6 +39,8 @@ def test_POST_settings_no_errors(pyramid_config, pyramid_req):
         ('persona.audiences', 'http://localhost'),
         ('fireblog.recaptcha_secret',
             'ssssssssssssssssssssssssssssssssssssssss'),
+        ('fireblog.recaptcha_site_key',
+            'ssssssssssssssssssssssssssssssssssssssst'),
         ('fireblog.theme', 'polymer')]
     pyramid_req.params.update(correct_params)
     with transaction.manager:
@@ -56,6 +60,8 @@ def test_POST_settings_some_errors(pyramid_config, pyramid_req, monkeypatch):
         ('persona.audiences', 'http://localhost'),
         ('fireblog.recaptcha_secret',
             'ssssssssssssssssssssssssssssssssssssssss'),
+        ('fireblog.recaptcha_site_key',
+            'sssssssssssssssssssssssssssssssssssssssq'),
         ('fireblog.theme', 'polymer')]
     pyramid_req.params.update(params_with_some_errors)
     mock_settings_dict = {}
@@ -95,6 +101,7 @@ def test_POST_settings_all_errors(pyramid_config, pyramid_req, monkeypatch):
         '"Persona secret" setting was not provided, and is required.',
         '"Persona audiences" setting was not provided, and is required.',
         'Recaptcha secret is invalid.',
+        '"Recaptcha site key" setting was not provided, and is required.',
         'Blog theme is invalid.']
     assert pyramid_req.session.peek_flash() == expected_errors
     assert mock_settings_dict == {}

--- a/fireblog/tests/settings/views_test.py
+++ b/fireblog/tests/settings/views_test.py
@@ -15,7 +15,7 @@ def test_GET_settings(pyramid_config, pyramid_req, theme):
         ('persona.siteName', 'sitename'),
         ('persona.secret', 'seekret'),
         ('persona.audiences', 'http://localhost'),
-        ('fireblog.recaptcha-secret',
+        ('fireblog.recaptcha_secret',
          'secretsecretsecretsecretsecretsecretsecr'),
         ('fireblog.theme', theme)))
     expected_mapping = []
@@ -35,7 +35,7 @@ def test_POST_settings_no_errors(pyramid_config, pyramid_req):
         ('persona.siteName', 'sitename'),
         ('persona.secret', 'seekret'),
         ('persona.audiences', 'http://localhost'),
-        ('fireblog.recaptcha-secret',
+        ('fireblog.recaptcha_secret',
             'ssssssssssssssssssssssssssssssssssssssss'),
         ('fireblog.theme', 'polymer')]
     pyramid_req.params.update(correct_params)
@@ -54,7 +54,7 @@ def test_POST_settings_some_errors(pyramid_config, pyramid_req, monkeypatch):
         ('persona.siteName', ''),
         ('persona.secret', 'seekret'),
         ('persona.audiences', 'http://localhost'),
-        ('fireblog.recaptcha-secret',
+        ('fireblog.recaptcha_secret',
             'ssssssssssssssssssssssssssssssssssssssss'),
         ('fireblog.theme', 'polymer')]
     pyramid_req.params.update(params_with_some_errors)
@@ -78,7 +78,7 @@ def test_POST_settings_all_errors(pyramid_config, pyramid_req, monkeypatch):
         ('persona.siteName', ''),
         ('persona.secret', ''),
         ('persona.audiences', ''),
-        ('fireblog.recaptcha-secret',
+        ('fireblog.recaptcha_secret',
             'sssssssssssssssssssssssssssssssssssssssss'),
         ('fireblog.theme', 'Polymer')]
     pyramid_req.params.update(params_with_all_errors)


### PR DESCRIPTION
Instead of hardcoding the Recaptcha site/client key, store it in the settings table
