### PR TITLE
Feature/refactor init code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 
+# Show warnings about any invalid references when building docs
+nitpicky = True
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 

--- a/docs/fireblog.rst
+++ b/docs/fireblog.rst
@@ -7,6 +7,8 @@ Subpackages
 .. toctree::
 
     fireblog.scripts
+    fireblog.settings
+    fireblog.tests
 
 Submodules
 ----------
@@ -15,6 +17,14 @@ fireblog.comments module
 ------------------------
 
 .. automodule:: fireblog.comments
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.dogpile_region module
+------------------------------
+
+.. automodule:: fireblog.dogpile_region
     :members:
     :undoc-members:
     :show-inheritance:
@@ -35,6 +45,14 @@ fireblog.htmltruncate module
     :undoc-members:
     :show-inheritance:
 
+fireblog.login module
+---------------------
+
+.. automodule:: fireblog.login
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 fireblog.models module
 ----------------------
 
@@ -43,10 +61,34 @@ fireblog.models module
     :undoc-members:
     :show-inheritance:
 
+fireblog.renderer_globals module
+--------------------------------
+
+.. automodule:: fireblog.renderer_globals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 fireblog.tags module
 --------------------
 
 .. automodule:: fireblog.tags
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tasks module
+---------------------
+
+.. automodule:: fireblog.tasks
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.theme module
+---------------------
+
+.. automodule:: fireblog.theme
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/fireblog.settings.rst
+++ b/docs/fireblog.settings.rst
@@ -1,0 +1,46 @@
+fireblog.settings package
+=========================
+
+Submodules
+----------
+
+fireblog.settings.db_wrapper module
+-----------------------------------
+
+.. automodule:: fireblog.settings.db_wrapper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.settings.mapping module
+--------------------------------
+
+.. automodule:: fireblog.settings.mapping
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.settings.validators module
+-----------------------------------
+
+.. automodule:: fireblog.settings.validators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.settings.views module
+------------------------------
+
+.. automodule:: fireblog.settings.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fireblog.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/fireblog.tests.rst
+++ b/docs/fireblog.tests.rst
@@ -1,0 +1,93 @@
+fireblog.tests package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    fireblog.tests.settings
+
+Submodules
+----------
+
+fireblog.tests.comments_test module
+-----------------------------------
+
+.. automodule:: fireblog.tests.comments_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.conftest module
+------------------------------
+
+.. automodule:: fireblog.tests.conftest
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.functional_tests module
+--------------------------------------
+
+.. automodule:: fireblog.tests.functional_tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.login_test module
+--------------------------------
+
+.. automodule:: fireblog.tests.login_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.models_test module
+---------------------------------
+
+.. automodule:: fireblog.tests.models_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.renderer_globals_test module
+-------------------------------------------
+
+.. automodule:: fireblog.tests.renderer_globals_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.tags_test module
+-------------------------------
+
+.. automodule:: fireblog.tests.tags_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.tasks_test module
+--------------------------------
+
+.. automodule:: fireblog.tests.tasks_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.views_test module
+--------------------------------
+
+.. automodule:: fireblog.tests.views_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fireblog.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/fireblog.tests.settings.rst
+++ b/docs/fireblog.tests.settings.rst
@@ -1,0 +1,54 @@
+fireblog.tests.settings package
+===============================
+
+Submodules
+----------
+
+fireblog.tests.settings.conftest module
+---------------------------------------
+
+.. automodule:: fireblog.tests.settings.conftest
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.settings.db_wrapper_test module
+----------------------------------------------
+
+.. automodule:: fireblog.tests.settings.db_wrapper_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.settings.mapping_test module
+-------------------------------------------
+
+.. automodule:: fireblog.tests.settings.mapping_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.settings.validators_test module
+----------------------------------------------
+
+.. automodule:: fireblog.tests.settings.validators_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fireblog.tests.settings.views_test module
+-----------------------------------------
+
+.. automodule:: fireblog.tests.settings.views_test
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fireblog.tests.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -1,7 +1,5 @@
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
-from pyramid.response import Response
-import fireblog.utils as utils
 from fireblog.settings import (
     settings_dict,
     make_sure_all_settings_exist_and_are_valid
@@ -15,23 +13,6 @@ import logging
 
 
 log = logging.getLogger(__name__)
-
-
-def template_response_adapter(s: utils.TemplateResponseDict):
-    """This function works in tandem with
-    :py:class:`fireblog.utils.TemplateResponseDict`. This function assumes s
-    is an instance of :py:func:`fireblog.utils.TemplateResponseDict` and
-    returns a :py:class:`pyramid.response.Response` containing a string
-    representation of s."""
-    assert isinstance(s, utils.TemplateResponseDict)
-    # We need to return a Response() object, as per the Pyramid specs. But we
-    # want to not store a string in the Response yet, but an arbitrary dict
-    # as after this function returns, :py:func:`use_template` will do further
-    # processing on this arbitrary dict. So we set a custom field on this
-    # Respnse object, which we can retrieve in :py:func:`use_template`.
-    response = Response()
-    response._fireblog_custom_response = s
-    return response
 
 
 def add_routes(config):
@@ -52,6 +33,7 @@ def add_routes(config):
 
 def include_all_components(config):
     add_routes(config)
+    config.include('fireblog.theme')
     config.include('fireblog.renderer_globals')
     config.include('fireblog.settings')
     config.include('fireblog.comments', route_prefix='/comment')
@@ -107,8 +89,6 @@ def main(global_config, **settings):
     config.include('pyramid_mako')
     config.include('fireblog.login')
     config.add_static_view(name='bower', path='fireblog:../bower_components')
-    config.add_response_adapter(
-        template_response_adapter, utils.TemplateResponseDict)
     include_all_components(config)
     config.scan()
     return config.make_wsgi_app()

--- a/fireblog/comments.py
+++ b/fireblog/comments.py
@@ -4,6 +4,7 @@ import fireblog.events as events
 from fireblog.utils import urlify as u
 from fireblog.views import invalidate_current_post
 from fireblog.settings import settings_dict
+from fireblog.theme import render_to_response
 import requests
 import logging
 from pyramid.view import view_config
@@ -28,7 +29,7 @@ def add_comment_section_below_posts(event) -> None:
     the event parameter."""
     comments_list = render_comments_list_from_event(event)
     comment_add_url = event.request.route_url('comment_add')
-    html = utils.render_to_response('comments.mako',
+    html = render_to_response('comments.mako',
                                     {'comments': comments_list,
                                      'comment_add_url': comment_add_url,
                                      'post_title': event.post.name,

--- a/fireblog/comments.py
+++ b/fireblog/comments.py
@@ -30,11 +30,11 @@ def add_comment_section_below_posts(event) -> None:
     comments_list = render_comments_list_from_event(event)
     comment_add_url = event.request.route_url('comment_add')
     html = render_to_response('comments.mako',
-                                    {'comments': comments_list,
-                                     'comment_add_url': comment_add_url,
-                                     'post_title': event.post.name,
-                                     'post_id': event.post.id},
-                                    event.request).text
+                              {'comments': comments_list,
+                               'comment_add_url': comment_add_url,
+                               'post_title': event.post.name,
+                               'post_id': event.post.id},
+                              event.request).text
     event.sections.append(html)
 
 

--- a/fireblog/login.py
+++ b/fireblog/login.py
@@ -1,0 +1,63 @@
+from pyramid.authentication import AuthTktAuthenticationPolicy
+from pyramid.security import Allow, ALL_PERMISSIONS
+from sqlalchemy.orm.exc import NoResultFound
+from fireblog.models import (
+    DBSession,
+    Users
+)
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class Root(object):
+    """Resource tree to map groups to permissions. We allow admins to do
+    anything, and commenters to be able to comment only.
+    """
+    __acl__ = [
+        (Allow, 'g:admin', ALL_PERMISSIONS),
+        (Allow, 'g:commenter', 'add-comment'),
+    ]
+
+    def __init__(self, request):
+        self.request = request
+
+
+def groupfinder(userid, request) -> list:
+    """Looks up and returns the groups the userid belongs to.
+    If the userid doesn't exist, they are created as a commenter, and the
+    group they belong to (g:commenter) is returned."""
+    query = DBSession.query(Users). \
+        filter(Users.userid == userid)
+    try:
+        user = query.one()
+        return [user.group]
+    except NoResultFound:
+        group = create_commenter_and_return_group(userid)
+        return [group]
+
+
+def create_commenter_and_return_group(userid) -> str:
+    """This function assumes userid doesn't exist in the db, and creates a new
+    user with this userid, as a commenter.
+
+    :return: group the user belongs to (g:commenter)"""
+    group = 'g:commenter'
+    new_user = Users(userid=userid, group=group)
+    DBSession.add(new_user)
+    log.info('New commenter {} has been created'.format(userid))
+    return group
+
+
+def includeme(config):
+    settings = config.registry.settings
+    config.include("pyramid_persona")
+    config.commit()
+    config.set_root_factory(Root)
+    authn_policy = AuthTktAuthenticationPolicy(
+        settings['persona.secret'],
+        callback=groupfinder)
+    config.set_authentication_policy(authn_policy)
+    # Pyramid_persona has already set an authorization policy, so
+    # this has not been done here.

--- a/fireblog/renderer_globals.py
+++ b/fireblog/renderer_globals.py
@@ -5,6 +5,7 @@ from fireblog.models import (
     DBSession,
     Users
 )
+import functools
 import logging
 
 
@@ -34,7 +35,7 @@ def add_renderer_globals(event):
     event['settings_dict'] = settings_dict
     event['urlify'] = utils.urlify
     event['get_username'] = get_username
-    event['get_bower_url'] = get_bower_url
+    event['get_bower_url'] = functools.partial(get_bower_url, event['request'])
 
 
 def includeme(config):

--- a/fireblog/renderer_globals.py
+++ b/fireblog/renderer_globals.py
@@ -34,8 +34,8 @@ def add_renderer_globals(event):
     event['settings_dict'] = settings_dict
     event['urlify'] = utils.urlify
     event['get_username'] = get_username
+    event['get_bower_url'] = get_bower_url
 
 
 def includeme(config):
-    config.add_request_method(get_bower_url)
     config.add_subscriber(add_renderer_globals, BeforeRender)

--- a/fireblog/renderer_globals.py
+++ b/fireblog/renderer_globals.py
@@ -1,0 +1,49 @@
+from pyramid.events import BeforeRender
+import fireblog.utils as utils
+from fireblog.settings import settings_dict
+from fireblog.models import (
+    DBSession,
+    Users
+)
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+def get_bower_url(request, path_to_resource: str) -> str:
+    """Generate a url which points to the supplied path_or_resource.
+    The path_or_resource must exist in the /bower_components folder which is
+    located ../../bower_components relative to the file this function is in."""
+    asset = 'fireblog:../bower_components/' + path_to_resource
+    return request.static_url(asset)
+
+
+def get_username(email_address: str):
+    """Gets the username associated with the supplied email address from the
+    db."""
+    user = DBSession.query(Users.userid, Users.username).filter_by(
+        userid=email_address).first()
+    if not user:
+        log.info('Did not get username for email {}'.format(email_address))
+        return ''
+    return user.username
+
+
+def add_username_function(event):
+    event['get_username'] = get_username
+
+
+def add_urlify_function(event):
+    event['urlify'] = utils.urlify
+
+
+def add_settings_dict_to_templates(event):
+    event['settings_dict'] = settings_dict
+
+
+def includeme(config):
+    config.add_request_method(get_bower_url)
+    config.add_subscriber(add_username_function, BeforeRender)
+    config.add_subscriber(add_urlify_function, BeforeRender)
+    config.add_subscriber(add_settings_dict_to_templates, BeforeRender)

--- a/fireblog/renderer_globals.py
+++ b/fireblog/renderer_globals.py
@@ -30,20 +30,12 @@ def get_username(email_address: str):
     return user.username
 
 
-def add_username_function(event):
-    event['get_username'] = get_username
-
-
-def add_urlify_function(event):
-    event['urlify'] = utils.urlify
-
-
-def add_settings_dict_to_templates(event):
+def add_renderer_globals(event):
     event['settings_dict'] = settings_dict
+    event['urlify'] = utils.urlify
+    event['get_username'] = get_username
 
 
 def includeme(config):
     config.add_request_method(get_bower_url)
-    config.add_subscriber(add_username_function, BeforeRender)
-    config.add_subscriber(add_urlify_function, BeforeRender)
-    config.add_subscriber(add_settings_dict_to_templates, BeforeRender)
+    config.add_subscriber(add_renderer_globals, BeforeRender)

--- a/fireblog/settings/views.py
+++ b/fireblog/settings/views.py
@@ -1,5 +1,5 @@
 from fireblog.settings import mapping, settings_dict, validate_value
-from fireblog.utils import use_template, TemplateResponseDict
+from fireblog.theme import use_template, TemplateResponseDict
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound
 import logging

--- a/fireblog/tags.py
+++ b/fireblog/tags.py
@@ -2,7 +2,7 @@
 from operator import attrgetter
 import logging
 import fireblog.utils as utils
-from fireblog.utils import use_template, TemplateResponseDict
+from fireblog.theme import use_template, TemplateResponseDict
 from pyramid.view import view_config
 from pyramid.httpexceptions import (
     HTTPFound,

--- a/fireblog/templates/bootstrap/base.mako
+++ b/fireblog/templates/bootstrap/base.mako
@@ -12,8 +12,8 @@
   <%block name = "head">
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-    <link rel="stylesheet" href="${request.get_bower_url('simplemde/dist/simplemde.min.css')}">
-    <script src="${request.get_bower_url('simplemde/dist/simplemde.min.js')}"></script>
+    <link rel="stylesheet" href="${get_bower_url('simplemde/dist/simplemde.min.css')}">
+    <script src="${get_bower_url('simplemde/dist/simplemde.min.js')}"></script>
 
     <!-- Custom styles for this template -->
     <style>

--- a/fireblog/templates/bootstrap/edit.mako
+++ b/fireblog/templates/bootstrap/edit.mako
@@ -2,8 +2,8 @@
 
 <%block name="head">
 ${parent.head()}
-<link rel="stylesheet" href="${request.get_bower_url('simplemde/dist/simplemde.min.css')}">
-<script src="${request.get_bower_url('simplemde/dist/simplemde.min.js')}"></script>
+<link rel="stylesheet" href="${get_bower_url('simplemde/dist/simplemde.min.css')}">
+<script src="${get_bower_url('simplemde/dist/simplemde.min.js')}"></script>
 </%block>
 
 <%block name="header">${title}</%block>

--- a/fireblog/templates/polymer/base.mako
+++ b/fireblog/templates/polymer/base.mako
@@ -11,17 +11,17 @@
     <title>${settings_dict['persona.siteName']}</title>
 
     <%block name="head">
-    <script src="${request.get_bower_url('webcomponentsjs/webcomponents-lite.min.js')}">
+    <script src="${get_bower_url('webcomponentsjs/webcomponents-lite.min.js')}">
     </script>
     <link href='//fonts.googleapis.com/css?family=Ubuntu' rel='stylesheet' type='text/css'>
     <!-- Custom styles for this template -->
     <style is="custom-style">
         <%include file="polymer-custom-theme.css.mako"/>
     </style>
-    <link rel="import" href="${request.get_bower_url('paper-toolbar/paper-toolbar.html')}">
-    <link rel="import" href="${request.get_bower_url('paper-scroll-header-panel/paper-scroll-header-panel.html')}">
-    <link rel="import" href="${request.get_bower_url('paper-material/paper-material.html')}">
-    <link rel="import" href="${request.get_bower_url('paper-toast/paper-toast.html')}">
+    <link rel="import" href="${get_bower_url('paper-toolbar/paper-toolbar.html')}">
+    <link rel="import" href="${get_bower_url('paper-scroll-header-panel/paper-scroll-header-panel.html')}">
+    <link rel="import" href="${get_bower_url('paper-material/paper-material.html')}">
+    <link rel="import" href="${get_bower_url('paper-toast/paper-toast.html')}">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/fireblog/templates/polymer/edit.mako
+++ b/fireblog/templates/polymer/edit.mako
@@ -5,8 +5,8 @@
 <%block name="head">
 ${parent.head()}
 <link rel="import" href="${request.static_url('fireblog:static/form-submit.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-input.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-textarea.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-input.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-textarea.html')}">
 </%block>
 
 <%block name="content">

--- a/fireblog/templates/polymer/navbar.mako
+++ b/fireblog/templates/polymer/navbar.mako
@@ -1,11 +1,11 @@
 <%inherit file="base.mako"/>
 <%block name="head">
 ${parent.head()}
-<link rel="import" href="${request.get_bower_url('paper-icon-button/paper-icon-button.html')}">
-<link rel="import" href="${request.get_bower_url('iron-icons/iron-icons.html')}">
-<link rel="import" href="${request.get_bower_url('paper-fab/paper-fab.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-input.html')}">
-<link rel="import" href="${request.get_bower_url('paper-dialog/paper-dialog.html')}">
+<link rel="import" href="${get_bower_url('paper-icon-button/paper-icon-button.html')}">
+<link rel="import" href="${get_bower_url('iron-icons/iron-icons.html')}">
+<link rel="import" href="${get_bower_url('paper-fab/paper-fab.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-input.html')}">
+<link rel="import" href="${get_bower_url('paper-dialog/paper-dialog.html')}">
 </%block>
 
 <%block name="header_toolbar">

--- a/fireblog/templates/polymer/post.mako
+++ b/fireblog/templates/polymer/post.mako
@@ -3,10 +3,10 @@
 <%block name="head">
 ${parent.head()}
 <link rel="import" href="${request.static_url('fireblog:static/form-submit.html')}">
-<link rel="import" href="${request.get_bower_url('paper-item/paper-item.html')}">
-<link rel="import" href="${request.get_bower_url('paper-item/paper-item-body.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-textarea.html')}">
-<link rel="import" href="${request.get_bower_url('paper-button/paper-button.html')}">
+<link rel="import" href="${get_bower_url('paper-item/paper-item.html')}">
+<link rel="import" href="${get_bower_url('paper-item/paper-item-body.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-textarea.html')}">
+<link rel="import" href="${get_bower_url('paper-button/paper-button.html')}">
 </%block>
 
 <%block name="content">

--- a/fireblog/templates/polymer/settings.mako
+++ b/fireblog/templates/polymer/settings.mako
@@ -3,7 +3,7 @@
 <%block name="head">
 ${parent.head()}
 <link rel="import" href="${request.static_url('fireblog:static/form-submit.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-input.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-input.html')}">
 </%block>
 
 <%block name="header">Settings</%block>

--- a/fireblog/templates/polymer/tag_manager.mako
+++ b/fireblog/templates/polymer/tag_manager.mako
@@ -5,8 +5,8 @@
 <%block name="head">
 ${parent.head()}
 <link rel="import" href="${request.static_url('fireblog:static/form-submit.html')}">
-<link rel="import" href="${request.get_bower_url('paper-checkbox/paper-checkbox.html')}">
-<link rel="import" href="${request.get_bower_url('paper-input/paper-input.html')}">
+<link rel="import" href="${get_bower_url('paper-checkbox/paper-checkbox.html')}">
+<link rel="import" href="${get_bower_url('paper-input/paper-input.html')}">
 </%block>
 
 <%block name="content">

--- a/fireblog/tests/__init___test.py
+++ b/fireblog/tests/__init___test.py
@@ -4,21 +4,6 @@ import fireblog
 pytestmark = pytest.mark.usefixtures("test_with_one_theme")
 
 
-class Test_groupfinder:
-
-    def test_success(self, persona_test_admin_login,
-                     pyramid_config, pyramid_req):
-        emails = ['id5489746@mockmyid.com', persona_test_admin_login['email']]
-        for email in emails:
-            res = fireblog.groupfinder(email, pyramid_req)
-            assert res == ['g:admin']
-
-    def test_failure(self, pyramid_config, pyramid_req):
-        fake_email = 'some_fake_address@example.com'
-        res = fireblog.groupfinder(fake_email, pyramid_req)
-        assert res == ['g:commenter']
-
-
 class Test_getusername:
 
     @pytest.mark.parametrize('email, username', [

--- a/fireblog/tests/__init___test.py
+++ b/fireblog/tests/__init___test.py
@@ -4,19 +4,6 @@ import fireblog
 pytestmark = pytest.mark.usefixtures("test_with_one_theme")
 
 
-class Test_getusername:
-
-    @pytest.mark.parametrize('email, username', [
-        ('id5489746@mockmyid.com', 'id5489746'),
-        ('commenter@example.com', 'commenter')
-    ])
-    def test_success(self, pyramid_config, email, username):
-        assert fireblog.get_username(email) == username
-
-    def test_failure(self, pyramid_config):
-        assert fireblog.get_username('nonexistentemail@example.com') == ''
-
-
 class Test_get_secret_settings:
 
     @staticmethod

--- a/fireblog/tests/login_test.py
+++ b/fireblog/tests/login_test.py
@@ -1,0 +1,19 @@
+import pytest
+import fireblog.login as login
+
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
+class Test_groupfinder:
+
+    def test_success(self, persona_test_admin_login,
+                     pyramid_config, pyramid_req):
+        emails = ['id5489746@mockmyid.com', persona_test_admin_login['email']]
+        for email in emails:
+            res = login.groupfinder(email, pyramid_req)
+            assert res == ['g:admin']
+
+    def test_failure(self, pyramid_config, pyramid_req):
+        fake_email = 'some_fake_address@example.com'
+        res = login.groupfinder(fake_email, pyramid_req)
+        assert res == ['g:commenter']

--- a/fireblog/tests/renderer_globals_test.py
+++ b/fireblog/tests/renderer_globals_test.py
@@ -15,4 +15,5 @@ class Test_getusername:
         assert renderer_globals.get_username(email) == username
 
     def test_failure(self, pyramid_config):
-        assert renderer_globals.get_username('nonexistentemail@example.com') == ''
+        assert renderer_globals.get_username(
+            'nonexistentemail@example.com') == ''

--- a/fireblog/tests/renderer_globals_test.py
+++ b/fireblog/tests/renderer_globals_test.py
@@ -1,0 +1,18 @@
+import pytest
+import fireblog.renderer_globals as renderer_globals
+
+
+pytestmark = pytest.mark.usefixtures("test_with_one_theme")
+
+
+class Test_getusername:
+
+    @pytest.mark.parametrize('email, username', [
+        ('id5489746@mockmyid.com', 'id5489746'),
+        ('commenter@example.com', 'commenter')
+    ])
+    def test_success(self, pyramid_config, email, username):
+        assert renderer_globals.get_username(email) == username
+
+    def test_failure(self, pyramid_config):
+        assert renderer_globals.get_username('nonexistentemail@example.com') == ''

--- a/fireblog/theme.py
+++ b/fireblog/theme.py
@@ -21,7 +21,7 @@ class TemplateResponseDict(dict):
     render it to a response.
 
     This class is used in tandem with
-    :py:func:`fireblog.template_response_adapter`'''
+    :py:func:`template_response_adapter`'''
     pass
 
 
@@ -57,8 +57,8 @@ def render_to_response(template, res, request):
 
 def template_response_adapter(s: TemplateResponseDict):
     """This function works in tandem with
-    :py:class:`fireblog.utils.TemplateResponseDict`. This function assumes s
-    is an instance of :py:func:`fireblog.utils.TemplateResponseDict` and
+    :py:class:`TemplateResponseDict`. This function assumes s
+    is an instance of :py:func:`TemplateResponseDict` and
     returns a :py:class:`pyramid.response.Response` containing a string
     representation of s."""
     assert isinstance(s, TemplateResponseDict)

--- a/fireblog/theme.py
+++ b/fireblog/theme.py
@@ -1,0 +1,28 @@
+'''
+Code that allows for changing the template files used at runtime. This
+provides support for themes, which are just folders containing template files.
+'''
+import fireblog.utils as utils
+from pyramid.response import Response
+
+
+def template_response_adapter(s: utils.TemplateResponseDict):
+    """This function works in tandem with
+    :py:class:`fireblog.utils.TemplateResponseDict`. This function assumes s
+    is an instance of :py:func:`fireblog.utils.TemplateResponseDict` and
+    returns a :py:class:`pyramid.response.Response` containing a string
+    representation of s."""
+    assert isinstance(s, utils.TemplateResponseDict)
+    # We need to return a Response() object, as per the Pyramid specs. But we
+    # want to not store a string in the Response yet, but an arbitrary dict
+    # as after this function returns, :py:func:`use_template` will do further
+    # processing on this arbitrary dict. So we set a custom field on this
+    # Respnse object, which we can retrieve in :py:func:`use_template`.
+    response = Response()
+    response._fireblog_custom_response = s
+    return response
+
+
+def includeme(config):
+    config.add_response_adapter(
+        template_response_adapter, utils.TemplateResponseDict)

--- a/fireblog/theme.py
+++ b/fireblog/theme.py
@@ -2,7 +2,6 @@
 Code that allows for changing the template files used at runtime. This
 provides support for themes, which are just folders containing template files.
 '''
-import fireblog.utils as utils
 from fireblog.settings import settings_dict
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPException

--- a/fireblog/theme.py
+++ b/fireblog/theme.py
@@ -3,16 +3,65 @@ Code that allows for changing the template files used at runtime. This
 provides support for themes, which are just folders containing template files.
 '''
 import fireblog.utils as utils
+from fireblog.settings import settings_dict
 from pyramid.response import Response
+from pyramid.httpexceptions import HTTPException
+from pyramid import renderers
+import functools
+import logging
 
 
-def template_response_adapter(s: utils.TemplateResponseDict):
+log = logging.getLogger(__name__)
+
+
+class TemplateResponseDict(dict):
+    '''Instances of this dict can be used as the return type of a view callable
+    that is using the use_template decorator. The :py:func:`use_template`
+    decorator will notice that an instance of this type is being returned and
+    render it to a response.
+
+    This class is used in tandem with
+    :py:func:`fireblog.template_response_adapter`'''
+    pass
+
+
+def use_template(template: str=None):
+    """This decorator allows a view to be rendered using whatever the current
+    active template aka theme is."""
+    def wrapper(f, template=template):
+        @functools.wraps(f)
+        def inner(context, request):
+            res = f(context, request)
+            # Deal with eg HTTPFound or HTTPNotFound by just returning them.
+            if isinstance(res, HTTPException):
+                return res
+            # Pull out the custom dict object set by
+            # :py:func:`fireblog.template_response_adapter`
+            to_render = res._fireblog_custom_response
+            if not isinstance(to_render, dict):
+                raise Exception(  # pragma: no cover
+                    "The use_template decorator is being used "
+                    "incorrectly: the decorated view callable must return a "
+                    "dict.")
+            return render_to_response(template, to_render, request)
+        return inner
+    return wrapper
+
+
+def render_to_response(template, res, request):
+    theme = settings_dict['fireblog.theme']
+    template = 'fireblog:templates/' + theme + '/' + template
+    log.debug('Rendering template {}'.format(template))
+    return renderers.render_to_response(template, res, request)
+
+
+def template_response_adapter(s: TemplateResponseDict):
     """This function works in tandem with
     :py:class:`fireblog.utils.TemplateResponseDict`. This function assumes s
     is an instance of :py:func:`fireblog.utils.TemplateResponseDict` and
     returns a :py:class:`pyramid.response.Response` containing a string
     representation of s."""
-    assert isinstance(s, utils.TemplateResponseDict)
+    assert isinstance(s, TemplateResponseDict)
     # We need to return a Response() object, as per the Pyramid specs. But we
     # want to not store a string in the Response yet, but an arbitrary dict
     # as after this function returns, :py:func:`use_template` will do further
@@ -25,4 +74,4 @@ def template_response_adapter(s: utils.TemplateResponseDict):
 
 def includeme(config):
     config.add_response_adapter(
-        template_response_adapter, utils.TemplateResponseDict)
+        template_response_adapter, TemplateResponseDict)

--- a/fireblog/utils.py
+++ b/fireblog/utils.py
@@ -4,14 +4,7 @@ from fireblog.htmltruncate import truncate as truncate_html
 from fireblog.settings import settings_dict
 from fireblog.dogpile_region import region
 import arrow
-import functools
 import transaction
-from pyramid import renderers
-from pyramid.httpexceptions import HTTPException
-import logging
-
-
-log = logging.getLogger(__name__)
 
 
 def urlify(string: str) -> str:
@@ -23,47 +16,6 @@ def urlify(string: str) -> str:
 def format_datetime(datetime):
     '''Return a string representing the datetime object. eg \'20 Jan 2014\''''
     return arrow.get(datetime).format('DD MMM YYYY')
-
-
-class TemplateResponseDict(dict):
-    '''Instances of this dict can be used as the return type of a view callable
-    that is using the use_template decorator. The :py:func:`use_template`
-    decorator will notice that an instance of this type is being returned and
-    render it to a response.
-
-    This class is used in tandem with
-    :py:func:`fireblog.template_response_adapter`'''
-    pass
-
-
-def use_template(template: str=None):
-    """This decorator allows a view to be rendered using whatever the current
-    active template aka theme is."""
-    def wrapper(f, template=template):
-        @functools.wraps(f)
-        def inner(context, request):
-            res = f(context, request)
-            # Deal with eg HTTPFound or HTTPNotFound by just returning them.
-            if isinstance(res, HTTPException):
-                return res
-            # Pull out the custom dict object set by
-            # :py:func:`fireblog.template_response_adapter`
-            to_render = res._fireblog_custom_response
-            if not isinstance(to_render, dict):
-                raise Exception(  # pragma: no cover
-                    "The use_template decorator is being used "
-                    "incorrectly: the decorated view callable must return a "
-                    "dict.")
-            return render_to_response(template, to_render, request)
-        return inner
-    return wrapper
-
-
-def render_to_response(template, res, request):
-    theme = settings_dict['fireblog.theme']
-    template = 'fireblog:templates/' + theme + '/' + template
-    log.debug('Rendering template {}'.format(template))
-    return renderers.render_to_response(template, res, request)
 
 
 def get_anonymous_userid() -> str:

--- a/fireblog/views.py
+++ b/fireblog/views.py
@@ -2,7 +2,7 @@
 uuids.'''
 import fireblog.utils as utils
 import fireblog.events as events
-from fireblog.utils import use_template, TemplateResponseDict
+from fireblog.theme import use_template, TemplateResponseDict
 from fireblog.utils import urlify as u
 from fireblog.dogpile_region import region
 from fireblog.settings import settings_dict


### PR DESCRIPTION
Move as much stuff from the `fireblog/__init__.py` file into new files. Then, in `__init__.py`, we just `confi.include` all of these new files (which each have an `includeme` function). This provides several benefits:
1. Code is easier to read
2. Code is better separated into related sections
3. There is more control over the order of importing and setting up different parts of the webapp. This is the main driving reason behind this PR, as this is required for getting redis to work with the webapp in a later PR.

Docs have also been updated.
