### PR TITLE
Feature/add redis support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ version, see `my blog <https://blog.ismail-s.com>`_.
 Getting Started
 ---------------
 
+First make sure there is a running local instance of `redis <http://redis.io>`_.
+Then run the following commands:
+
 .. code:: bash
 
   git clone https://github.com/ismail-s/fireblog.git

--- a/development.ini
+++ b/development.ini
@@ -19,9 +19,6 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
-    pyramid_tm
-    pyramid_persona
-    pyramid_dogpile_cache
 
 sqlalchemy.url = sqlite:///%(here)s/fireblog.sqlite
 

--- a/development.ini
+++ b/development.ini
@@ -37,7 +37,7 @@ debugtoolbar.hosts = 127.0.0.1 ::1 192.168.0.20
 secrets = %(here)s/secrets-dev.ini
 
 # See http://dogpilecache.readthedocs.org/ for more info.
-dogpile_cache.backend = memory
+dogpile_cache.backend = redis
 
 [server:main]
 use = egg:waitress#main

--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -80,8 +80,8 @@ def main(global_config, **settings):
     # We have to import the settings module after setting up the cache, which
     # is done at the beginnning of this function.
     from fireblog.settings import (
-      settings_dict,
-       make_sure_all_settings_exist_and_are_valid
+        settings_dict,
+        make_sure_all_settings_exist_and_are_valid
     )
     make_sure_all_settings_exist_and_are_valid()
     # Add all settings from db that are needed for plugins (eg pyramid_persona)

--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -68,6 +68,7 @@ def main(global_config, **settings):
 
     :return: WSGI app
     """
+    config.include('pyramid_dogpile_cache')
     # Get extra config settings from secrets file
     secrets_file = settings.get('secrets', None)
     log.debug('Found secrets file {}'.format(secrets_file))
@@ -86,6 +87,8 @@ def main(global_config, **settings):
             settings[name] = value
 
     config = Configurator(settings=settings)
+    config.include('pyramid_tm')
+    config.include('pyramid_persona')
     config.include('pyramid_mako')
     config.include('fireblog.login')
     config.add_static_view(name='bower', path='fireblog:../bower_components')

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -52,7 +52,7 @@ def pyramid_req():
     return res
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def mydb(request, persona_test_admin_login, theme):
     engine = create_engine('sqlite://')
     DBSession.configure(bind=engine)
@@ -137,7 +137,7 @@ def pyramid_config(mydb, request):
     return config
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def setup_testapp(mydb, request):
     settings = {'sqlalchemy.url': 'sqlite://',
                 'persona.audiences': 'http://localhost',

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -158,6 +158,7 @@ def testapp(request, mydb, setup_testapp):
     testapp = setup_testapp
     mydb.begin(subtransactions=True)
     clear_dogpile_region()
+
     def fin():
         mydb.rollback()
         clear_dogpile_region()

--- a/fireblog/tests/conftest.py
+++ b/fireblog/tests/conftest.py
@@ -123,7 +123,6 @@ def mydb(request, persona_test_admin_login, theme):
 def pyramid_config(mydb, request):
     config = testing.setUp()
     config.include('pyramid_mako')
-    mydb.rollback()
     include_all_components(config)
     mydb.rollback()
     mydb.begin(subtransactions=True)
@@ -157,10 +156,8 @@ def setup_testapp(mydb, request):
 @pytest.fixture
 def testapp(request, mydb, setup_testapp):
     testapp = setup_testapp
-    mydb.rollback()
     mydb.begin(subtransactions=True)
     clear_dogpile_region()
-
     def fin():
         mydb.rollback()
         clear_dogpile_region()

--- a/production.ini
+++ b/production.ini
@@ -18,10 +18,6 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
-pyramid.includes =
-    pyramid_tm
-    pyramid_persona
-    pyramid_dogpile_cache
 
 # This optional setting allows you to spread configuration over 2 ini files.
 # This means that things like passwords and the like can be kept in a ini file

--- a/production.ini
+++ b/production.ini
@@ -27,7 +27,7 @@ secrets = %(here)s/secrets.ini
 sqlalchemy.url = sqlite:///%(here)s/fireblog.sqlite
 # See http://dogpilecache.readthedocs.org/ for more info. This variable
 # can be changed to eg redis to change the cache used.
-dogpile_cache.backend = memory
+dogpile_cache.backend = redis
 
 [server:main]
 use = egg:waitress#main


### PR DESCRIPTION
Fixes #63.

Note that in this PR, I have also changed the `mydb` fixture so it no longer runs once per test session, but once for each individual test that requires it. This is to sort out issues with the test db not being wiped between tests.
