### PR TITLE
Feature/move settings db check to script

### DIFF
--- a/fireblog/__init__.py
+++ b/fireblog/__init__.py
@@ -79,11 +79,7 @@ def main(global_config, **settings):
     Base.metadata.bind = engine
     # We have to import the settings module after setting up the cache, which
     # is done at the beginnning of this function.
-    from fireblog.settings import (
-        settings_dict,
-        make_sure_all_settings_exist_and_are_valid
-    )
-    make_sure_all_settings_exist_and_are_valid()
+    from fireblog.settings import settings_dict
     # Add all settings from db that are needed for plugins (eg pyramid_persona)
     # so that the plugins can access these settings.
     for name, value in settings_dict.items():

--- a/fireblog/scripts/initializedb.py
+++ b/fireblog/scripts/initializedb.py
@@ -40,7 +40,7 @@ Any issues, report them there.
 """
 
 
-def setup_first_post(DBSession,script_name):
+def setup_first_post(DBSession, script_name):
     # Don't setup first post if posts already exist. This may be the case
     # if the script is run on an existing db.
     if DBSession.query(Post).count() > 0:
@@ -59,6 +59,11 @@ def setup_first_post(DBSession,script_name):
         me = Users(userid=email_address,
                    group='g:admin')
         DBSession.add(me)
+
+
+def setup_settings_db():
+    from fireblog.settings import make_sure_all_settings_exist_and_are_valid
+    make_sure_all_settings_exist_and_are_valid()
 
 
 def run_alembic_migrations():
@@ -87,6 +92,7 @@ def main(argv=sys.argv):
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
     setup_first_post(DBSession, script_name=os.path.basename(argv[0]))
+    setup_settings_db()
     print('The database has now been setup.')
     print('Run "pserve {ini_file}" to start the blog'.format(
         ini_file=config_uri))

--- a/fireblog/scripts/initializedb.py
+++ b/fireblog/scripts/initializedb.py
@@ -61,10 +61,9 @@ def setup_first_post(DBSession,script_name):
         DBSession.add(me)
 
 
-
 def run_alembic_migrations():
     current_dir = Path(__file__).parent
-    alembic_cfg_file = current_dir/'..'/'..'/'alembic.ini'
+    alembic_cfg_file = current_dir / '..' / '..' / 'alembic.ini'
     alembic_cfg = Config(str(alembic_cfg_file.resolve()))
     command.upgrade(alembic_cfg, "head")
 

--- a/fireblog/scripts/initializedb.py
+++ b/fireblog/scripts/initializedb.py
@@ -1,3 +1,13 @@
+"""
+The initializedb or initialize_fireblog_db script works in 2 ways:
+
+1) It can initialise a db to be used for the blog
+2) If a db already exists, then it will:
+
+  a) Run migrations on it if necessary
+  b) Check the settings table in the db and make sure that all required
+     settings exist and are valid.
+"""
 import os
 from fireblog.compat import Path
 import sys

--- a/fireblog/scripts/initializedb.py
+++ b/fireblog/scripts/initializedb.py
@@ -39,6 +39,21 @@ For more information about this blog, see the
 Any issues, report them there.
 """
 
+def setup_first_post(DBSession):
+    post_markdown = first_post.format(script_name=os.path.basename(argv[0]))
+    email_address = input('Please provide an admin email address: ')
+    print('Creating the database for you...')
+    with transaction.manager:
+        post = Post(name='Hello World!',
+                    markdown=post_markdown,
+                    html=markdown(post_markdown))
+        DBSession.add(post)
+    with transaction.manager:
+        me = Users(userid=email_address,
+                   group='g:admin')
+        DBSession.add(me)
+
+
 
 def run_alembic_migrations():
     current_dir = Path(__file__).parent
@@ -65,18 +80,7 @@ def main(argv=sys.argv):
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
-    post_markdown = first_post.format(script_name=os.path.basename(argv[0]))
-    email_address = input('Please provide an admin email address: ')
-    print('Creating the database for you...')
-    with transaction.manager:
-        post = Post(name='Hello World!',
-                    markdown=post_markdown,
-                    html=markdown(post_markdown))
-        DBSession.add(post)
-    with transaction.manager:
-        me = Users(userid=email_address,
-                   group='g:admin')
-        DBSession.add(me)
+    setup_first_post(DBSession)
     print('The database has now been setup.')
     print('Run "pserve {ini_file}" to start the blog'.format(
         ini_file=config_uri))

--- a/fireblog/scripts/initializedb.py
+++ b/fireblog/scripts/initializedb.py
@@ -39,8 +39,15 @@ For more information about this blog, see the
 Any issues, report them there.
 """
 
-def setup_first_post(DBSession):
-    post_markdown = first_post.format(script_name=os.path.basename(argv[0]))
+
+def setup_first_post(DBSession,script_name):
+    # Don't setup first post if posts already exist. This may be the case
+    # if the script is run on an existing db.
+    if DBSession.query(Post).count() > 0:
+        print('Skipping setting up an initial post as there already exist '
+              'posts in the db')
+        return
+    post_markdown = first_post.format(script_name=script_name)
     email_address = input('Please provide an admin email address: ')
     print('Creating the database for you...')
     with transaction.manager:
@@ -80,7 +87,7 @@ def main(argv=sys.argv):
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
-    setup_first_post(DBSession)
+    setup_first_post(DBSession, script_name=os.path.basename(argv[0]))
     print('The database has now been setup.')
     print('Run "pserve {ini_file}" to start the blog'.format(
         ini_file=config_uri))

--- a/fireblog/settings/__init__.py
+++ b/fireblog/settings/__init__.py
@@ -15,25 +15,24 @@ def make_sure_all_settings_exist_and_are_valid():
     user.
     This function should only be run when the web app is starting up, as it
     requests user input from the command line."""
-    if len(settings_dict) != len(mapping):
-        with transaction.manager:
-            for entry in mapping:
-                try:
-                    value = settings_dict[entry.registry_name]
-                    valid, value, _ = validate_value(entry, value)
-                    if valid:
-                        continue
-                except KeyError:
-                    pass
-                while True:
-                    # Get value from user
-                    input_str = 'Please provide a value for the setting "{}": '
-                    user_val = input(input_str.format(entry.display_name))
-                    valid, value, _ = validate_value(entry, user_val)
-                    if valid:
-                        break
-                    print('That value is invalid.')
-                settings_dict[entry.registry_name] = value
+    with transaction.manager:
+        for entry in mapping:
+            try:
+                value = settings_dict[entry.registry_name]
+                valid, value, _ = validate_value(entry, value)
+                if valid:
+                    continue
+            except KeyError:
+                pass
+            while True:
+                # Get value from user
+                input_str = 'Please provide a value for the setting "{}": '
+                user_val = input(input_str.format(entry.display_name))
+                valid, value, _ = validate_value(entry, user_val)
+                if valid:
+                    break
+                print('That value is invalid.')
+            settings_dict[entry.registry_name] = value
 
 
 def validate_value(entry: Entry, value):

--- a/fireblog/settings/__init__.py
+++ b/fireblog/settings/__init__.py
@@ -13,8 +13,9 @@ def make_sure_all_settings_exist_and_are_valid():
     be in it, and make sure they both are in the settings table and are valid.
     For any that aren't valid or don't exist, we get a correct value from the
     user.
-    This function should only be run when the web app is starting up, as it
-    requests user input from the command line."""
+    This function is meant to be run as part of a console script, as it uses
+    STDIN to get user input, which doesn't work with some app servers eg
+    uwsgi."""
     with transaction.manager:
         for entry in mapping:
             try:


### PR DESCRIPTION
Fixes #65 by combining the settings db check into the initialize_fireblog_db script, which now creates a db, updates a db and makes sure the settings table is valid, all in one go and without having to tell it what needs doing (eg if a db already exists, it won't create one, if the db is up to date, it won't update it, and so on).
