### PR TITLE
Add missing redis requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ pathlib2
 uwsgi
 pastescript
 pastedeploy
+redis


### PR DESCRIPTION
I forgot to add this when switching to using redis as the default cache
