### PR TITLE
Make textboxes larger

### DIFF
--- a/fireblog/templates/simple/edit.mako
+++ b/fireblog/templates/simple/edit.mako
@@ -8,12 +8,15 @@
         <textarea autofocus="true"
             label="Enter the post content here"
             id="main-post"
-            name="body">${post_text}</textarea>
+            name="body"
+            style="width: 100%"
+            rows=10>${post_text}</textarea>
         <label for="tags">Tags (optional)</label>
         <input name="tags"
         id="tags"
         label="enter any tags here, separated by commas"
-        value="${tags}"></input>
+        value="${tags}"
+        style="width: 100%"></input>
         <input type="submit" name="form.submitted" value="Submit">
     </form>
 </%block>


### PR DESCRIPTION
Make textboxes for adding/editing a post fill the screen.
This is something I forgot to do when creating the simple theme.
Fixes #78.
