### PR TITLE
Feature/improve groupfinder func

### DIFF
--- a/fireblog/login.py
+++ b/fireblog/login.py
@@ -28,7 +28,7 @@ def groupfinder(userid, request) -> list:
     """Looks up and returns the groups the userid belongs to.
     If the userid doesn't exist, they are created as a commenter, and the
     group they belong to (g:commenter) is returned."""
-    query = DBSession.query(Users). \
+    query = DBSession.query(Users.group). \
         filter(Users.userid == userid)
     try:
         user = query.one()

--- a/fireblog/login.py
+++ b/fireblog/login.py
@@ -1,6 +1,7 @@
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.security import Allow, ALL_PERMISSIONS
 from sqlalchemy.orm.exc import NoResultFound
+from fireblog.dogpile_region import region
 from fireblog.models import (
     DBSession,
     Users
@@ -24,7 +25,8 @@ class Root(object):
         self.request = request
 
 
-def groupfinder(userid, request) -> list:
+@region.cache_on_arguments()
+def groupfinder(userid):
     """Looks up and returns the groups the userid belongs to.
     If the userid doesn't exist, they are created as a commenter, and the
     group they belong to (g:commenter) is returned."""
@@ -57,7 +59,7 @@ def includeme(config):
     config.set_root_factory(Root)
     authn_policy = AuthTktAuthenticationPolicy(
         settings['persona.secret'],
-        callback=groupfinder)
+        callback=lambda x, _: groupfinder(x))
     config.set_authentication_policy(authn_policy)
     # Pyramid_persona has already set an authorization policy, so
     # this has not been done here.

--- a/fireblog/tests/login_test.py
+++ b/fireblog/tests/login_test.py
@@ -6,14 +6,13 @@ pytestmark = pytest.mark.usefixtures("test_with_one_theme")
 
 class Test_groupfinder:
 
-    def test_success(self, persona_test_admin_login,
-                     pyramid_config, pyramid_req):
+    def test_success(self, persona_test_admin_login, pyramid_config):
         emails = ['id5489746@mockmyid.com', persona_test_admin_login['email']]
         for email in emails:
-            res = login.groupfinder(email, pyramid_req)
+            res = login.groupfinder(email)
             assert res == ['g:admin']
 
-    def test_failure(self, pyramid_config, pyramid_req):
+    def test_failure(self, pyramid_config):
         fake_email = 'some_fake_address@example.com'
-        res = login.groupfinder(fake_email, pyramid_req)
+        res = login.groupfinder(fake_email)
         assert res == ['g:commenter']


### PR DESCRIPTION
This is 2 minor perf improvements:
1. cache the groupfinder func.
2. when the groupfinder func actually does query the db, only get the necessary cols.
